### PR TITLE
Kpmp 445 save button fix

### DIFF
--- a/src/components/Slides/MenuSlideList.js
+++ b/src/components/Slides/MenuSlideList.js
@@ -4,9 +4,26 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCaretLeft, faChevronRight, faChevronLeft, faPrint, faDownload } from '@fortawesome/free-solid-svg-icons';
 
 class MenuSlideList extends Component {
+
+    constructor(props) {
+        super(props);
+        this.noSlidesFound = this.noSlidesFound.bind(this);
+    }
+
+    noSlidesFound() {
+        return Object.keys(this.props.selectedPatient).length === 0
+            && this.props.selectedPatient.constructor === Object;
+    }
+
     render() {
         console.log(this.props);
-    	return (
+    	return this.noSlidesFound() ? (
+            <Col id="menu-slide-list">
+                <Row className="slide-menu-item">
+                    <Col sm="12"> There are no slides to show. </Col>
+                </Row>
+            </Col>
+            ) : (
             <Col id="menu-slide-list">
             	<Row className="menu-slide-list-header">
             		<Col sm="11" >WHOLE SLIDE IMAGES</Col>
@@ -14,34 +31,33 @@ class MenuSlideList extends Component {
             			<FontAwesomeIcon icon={faCaretLeft} size="lg" onClick={this.props.onToggle} className="clickable"/>
             		</Col>
             	</Row>
-                <Row className="prev-next-buttons">
-                    <Button outline color={'secondary'}>
-                        <FontAwesomeIcon icon={faChevronLeft} size="2x"/>
-                    </Button>
-                    <Button outline color={'secondary'}>
-                        <FontAwesomeIcon icon={faDownload} size="2x"/>
-                    </Button>
-                    <Button outline color={'secondary'}>
-                        <FontAwesomeIcon icon={faPrint} size="2x"/>
-                    </Button>
-                    <Button outline color={'secondary'}>
-                        <FontAwesomeIcon icon={faChevronRight} size="2x"/>
-                    </Button>
+                <Row className="prev-next-buttons" noGutters>
+                    <Col>
+                        <Button outline color={'secondary'}>
+                            <FontAwesomeIcon icon={faDownload} size="2x"/>
+                        </Button>
+                        <Button outline color={'secondary'}>
+                            <FontAwesomeIcon icon={faPrint} size="2x"/>
+                        </Button>
+                    </Col>
+                    <Col>
+                        <Button outline color={'secondary'}>
+                            <FontAwesomeIcon icon={faChevronLeft} size="2x"/>
+                        </Button>
+                        <Button outline color={'secondary'}>
+                            <FontAwesomeIcon icon={faChevronRight} size="2x"/>
+                        </Button>
+                    </Col>
                 </Row>
             	<div id="menu-slide-list-slides">
-            	
-            	{Object.keys(this.props.selectedPatient).length === 0 && this.props.selectedPatient.constructor === Object  ? (
-            		<Row className="slide-menu-item">
-            			<Col sm="12"> There are no slides to show. </Col>
-            		</Row>
-            	) : (
-        			this.props.selectedPatient.map(function(slide, index) {
-                		return <Row className="slide-menu-item">
-                			<Col sm="2"><div className="thumbnail" /></Col>
-                			<Col sm="10" className="slide-name">{slide.slideName}</Col>
-                		</Row>;
-                	})
-            	)}
+                    {
+                        this.props.selectedPatient.map(function(slide, index) {
+                            return <Row className="slide-menu-item">
+                                <Col sm="2"><div className="thumbnail" /></Col>
+                                <Col sm="10" className="slide-name">{slide.slideName}</Col>
+                            </Row>
+                        })
+                    }
             	</div>
             	<Row className="divider" />
             	<Row>
@@ -52,7 +68,7 @@ class MenuSlideList extends Component {
                     </div>
                 </Row>
             </Col>
-        );
+        )
     }
 }
 

--- a/src/components/Slides/MenuSlideList.js
+++ b/src/components/Slides/MenuSlideList.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Button, Col, Row } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCaretLeft, faChevronRight, faChevronLeft, faPrint, faSave } from '@fortawesome/free-solid-svg-icons';
+import { faCaretLeft, faChevronRight, faChevronLeft, faPrint, faDownload } from '@fortawesome/free-solid-svg-icons';
 
 class MenuSlideList extends Component {
     render() {
@@ -19,7 +19,7 @@ class MenuSlideList extends Component {
                         <FontAwesomeIcon icon={faChevronLeft} size="2x"/>
                     </Button>
                     <Button outline color={'secondary'}>
-                        <FontAwesomeIcon icon={faSave} size="2x"/>
+                        <FontAwesomeIcon icon={faDownload} size="2x"/>
                     </Button>
                     <Button outline color={'secondary'}>
                         <FontAwesomeIcon icon={faPrint} size="2x"/>

--- a/src/index.scss
+++ b/src/index.scss
@@ -83,7 +83,8 @@ a:hover {
 	margin: auto;
 
 	.btn-primary {
-		background-color: #008ea8;
+		background-color: #BB0606;
+		border-color: #BB0606;
 	}
 
 	#patient-select-wrapper {
@@ -258,12 +259,13 @@ a:hover {
 			}
 
 			.prev-next-buttons {
-				padding: 15px;
-				max-width: 300px;
-				margin: auto;
+				margin: 15px auto;
+				max-width: 350px;
+				text-align: center;
 
 				.btn {
-					margin: 0 auto 0 auto;
+					margin: 0px 5px;
+
 				}
 			}
 


### PR DESCRIPTION
 - Uses download instead of save icon
 - Detaches download/print from prev/next buttons
 - Hides all "selected slide" content when there are no slides to show
